### PR TITLE
fix: unittest was complaining about the tempdir

### DIFF
--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -96,6 +96,10 @@ categories:
         with open(self.config_path, "w") as f:
             f.write(self.config_content)
 
+    def tearDown(self):
+        self.config_dir.cleanup()
+        self.config_dir = None
+
     def test_get_timecards_returns_list(self):
         import yaml
         with open(self.config_path, "r") as f:


### PR DESCRIPTION
Since we create the directory in setUp(), tempfile complains if you don't explicitly cleanup(). It still cleans up the directory, but since it is warning that you should do the cleanup, let's do it.

The last change is just adding a trailing newline to the file. Some editors always create them, some don't. But generally I think it is healthy to have them.