### PR TITLE
refactor flow for adding tasks

### DIFF
--- a/punch/commands.py
+++ b/punch/commands.py
@@ -12,7 +12,7 @@ from playwright.sync_api import TimeoutError
 from punch.config import set_config_value
 from punch.export import export_csv, export_json
 from punch.report import generate_report
-from punch.tasks import CMDLINE_SEPARATOR, parse_new_task_string, write_task
+from punch.tasks import CMDLINE_SEPARATOR, TaskEntry, parse_new_task_string, write_task
 from punch.web import DRY_RUN_SUFFIX, AuthFileNotFoundError, MissingTimecardsUrl, NoCaseMappingError, get_timecards, login_to_site, submit_timecards
 
     
@@ -196,16 +196,12 @@ def get_category_by_short(categories, arg_str):
             return cat, categories[cat]
     return None, None
 
-def handle_add(args, categories, tasks_file, console):
-    task_str = args.task_str
-    time = args.time
-
+def handle_add(_args, task: TaskEntry, tasks_file, console):
     try:
-        task = parse_new_task_string(task_str, categories)
-        write_task(tasks_file, task.category, task.task, task.notes, time)
-        print(f"Logged: {task.category} : {task.task} : {task.notes}")
+        write_task(tasks_file, task.category, task.task, task.notes, task.finish)
+        console.print(f"✓ Task logged: {task.category} : {task.task} : {task.notes}", style="bold green")
     except ValueError as e:
-        console.print(f"Error: {e}")
+        console.print(f"✗ Error saving task: {e}", style="bold red")
         sys.exit(1)
 
 def print_report(report):

--- a/punch/ui/interactive.py
+++ b/punch/ui/interactive.py
@@ -1,5 +1,6 @@
 """Textual-based interactive mode for Punch task management."""
 
+import datetime
 from typing import Optional
 from textual.app import App, ComposeResult
 from textual.containers import Vertical, Horizontal
@@ -7,7 +8,7 @@ from textual.widgets import Header, Footer, Button, Static, ListItem, ListView, 
 from textual.screen import ModalScreen
 from rich.console import Console
 
-from punch.tasks import get_recent_tasks, write_task
+from punch.tasks import TaskEntry, get_recent_tasks, write_task
 
 
 class NewTaskScreen(ModalScreen):
@@ -112,7 +113,7 @@ class NotesInputScreen(ModalScreen):
         self.dismiss((self.category, self.task_name, self.notes))
 
 
-class InteractiveApp(App):
+class InteractiveApp(App[TaskEntry]):
     """A Textual app for interactive task management."""
     
     CSS = """
@@ -276,16 +277,7 @@ class InteractiveApp(App):
     def on_notes_result(self, result) -> None:
         if result:
             category, task, notes = result
-            try:
-                write_task(self.tasks_file, category, task, notes)
-                # Show success message and exit
-                console = Console()
-                console.print(f"✓ Task logged: {category} : {task} : {notes}", style="bold green")
-                self.exit()
-            except Exception as e:
-                console = Console()
-                console.print(f"✗ Error saving task: {e}", style="bold red")
-                self.exit()
+            self.exit(TaskEntry(datetime.datetime.now(), category, task, notes, datetime.timedelta(0)))
         else:
             self.exit()
     
@@ -296,4 +288,4 @@ class InteractiveApp(App):
 def run_interactive_mode(categories, tasks_file, selected_category=None):
     """Launch the interactive Textual interface for task entry."""
     app = InteractiveApp(categories, tasks_file, selected_category)
-    app.run()
+    return app.run()


### PR DESCRIPTION
This PR rearchitects the code flow for adding a task as mentioned in #7.

The basic idea is to abstract over the source of a TaskEntry in the add command and then just pass the result on to a write stage.

I decided to avoid adding any support for add flags when invoking `punch` without a command as it would introduce ambiguity when calling something like `punch -t 12:00 add ...` vs `punch add -t 12:00 ...`

